### PR TITLE
catkin_make complains for malformed e-mail addresses

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,11 +4,11 @@
   <version>1.0.0</version>
   <description>The optoforce_etherdaq_driver package</description>
 
-  <maintainer email="ros(.at..)optoforce(.dot..)com">OptoForce</maintainer>
+  <maintainer email="ros@optoforce.com">OptoForce</maintainer>
 
   <license>BSD</license>
 
-  <author email="ros(.at..)optoforce(.dot..)com">OptoForce</author>
+  <author email="ros@optoforce.com">OptoForce</author>
 
 
   <buildtool_depend>catkin</buildtool_depend>
@@ -18,7 +18,7 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>tinyxml</build_depend>
-  
+
   <run_depend>curl</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
   <run_depend>diagnostic_updater</run_depend>


### PR DESCRIPTION
On our installation of ros indigo, on Ubuntu 14.04, catkin complains if the e-mail addresses are malformed. This is a proposition to fix the issue.
